### PR TITLE
Se creo un constructor estático

### DIFF
--- a/3. Redis Cache/HOL.A/NinjaLab.Redis/NinjaLab.Redis/Helpers/RedisHelper.cs
+++ b/3. Redis Cache/HOL.A/NinjaLab.Redis/NinjaLab.Redis/Helpers/RedisHelper.cs
@@ -16,8 +16,19 @@ namespace NinjaLab.Redis.Helpers
             "LkjmVSfgq3QudyrTIvsIjUZSEijb++ZF7U/5D5lp2xY=@ninjacampredis.redis.cache.windows.net?ssl=true";
         private static IRedisClient redisClient;
 
+        /// <summary>
+        /// Constructor estático, este es invocado cada vez que se hace referencia a un miembro estático.
+        /// De esta manera le quitamos la responsabilidad a los metodos estáticos de hacer la conexión con redis
+        /// para que se ocupen de la verdadera responsabilidad que debe tener el método.
+        /// https://msdn.microsoft.com/es-co/library/k9x6w0hc.aspx
+        /// </summary>
+        static RedisHelper()
+        {
+            RedisConnection();
+        }
+
         //Método requerido para establecer una conexión con el servicio de Redis
-        public static void RedisConnection()
+        private static void RedisConnection()
         {
             if (redisClient == null)
             {
@@ -28,7 +39,6 @@ namespace NinjaLab.Redis.Helpers
         //Permite Obtener la lista completa de datos almacenados en Redis
         public static List<Event> GetAll()
         {
-            RedisConnection();
             var lstEvents = new List<Event>();
             var keys = redisClient.GetAllKeys();
             if (keys != null && keys.Count() > 0)
@@ -44,20 +54,17 @@ namespace NinjaLab.Redis.Helpers
         //Permite obtener solo el registro correspondiente a un Id
         public static Event Get(string id)
         {
-            RedisConnection();
             var response = redisClient.Get<string>(id);
             return response != null ? JsonConvert.DeserializeObject<Event>(response) : null;
         }
         //Permite remover o eliminar un registro de la cache según su Id
         public static bool Remove(string id)
         {
-            RedisConnection();
             return redisClient.Remove(id);
         }
         //Permite almacenar o guardar un registro en redis cache con su Id respectivo
         public static bool Set(Event @event)
         {
-            RedisConnection();
             return redisClient.Set(@event.Id.ToString(), JsonConvert.SerializeObject(@event));
         }
     }


### PR DESCRIPTION
se creo un constructor estático, este es invocado cada vez que se hace referencia a un miembro estático.
De esta manera le quitamos la responsabilidad a los métodos estáticos de hacer la conexión con redis
